### PR TITLE
Support configuring DNS port for resolver rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ module "route53-rule-ad-corp" {
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| associated\_vpcs | List of VPC IDs to associate rule to | list(string) | n/a | yes |
-| forward\_domain | Domain name to forward requests for | string | n/a | yes |
-| forward\_ips | List of IPs to forward DNS requests to | list(string) | n/a | yes |
-| resolver\_endpoint | Resolver Endpoint ID | string | n/a | yes |
-| resource\_share\_accounts | List of account IDs to share this resolver rule with | list(string) | `[]` | no |
-| tags | Map of tags to apply to supported resources | map(string) | `{}` | no |
+|------|-------------|------|---------|:--------:|
+| associated\_vpcs | List of VPC IDs to associate rule to | `list(string)` | n/a | yes |
+| dns\_port | DNS port to forward DNS requests to | `number` | `53` | no |
+| forward\_domain | Domain name to forward requests for | `string` | n/a | yes |
+| forward\_ips | List of IPs to forward DNS requests to | `list(string)` | n/a | yes |
+| resolver\_endpoint | Resolver Endpoint ID | `string` | n/a | yes |
+| resource\_share\_accounts | List of account IDs to share this resolver rule with | `list(string)` | `[]` | no |
+| tags | Map of tags to apply to supported resources | `map(string)` | `{}` | no |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,8 @@ resource "aws_route53_resolver_rule" "fwd" {
     for_each = var.forward_ips
 
     content {
-      ip = target_ip.value
+      ip   = target_ip.value
+      port = var.dns_port
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,12 @@ variable "forward_ips" {
   type        = list(string)
 }
 
+variable "dns_port" {
+  type        = number
+  description = "DNS port to forward DNS requests to"
+  default     = 53
+}
+
 variable "resolver_endpoint" {
   description = "Resolver Endpoint ID"
   type        = string


### PR DESCRIPTION
Essentially doing the same as I did for the resolver endpoint in https://github.com/rhythmictech/terraform-aws-route53-endpoint/pull/5