### PR TITLE
VPC assignment optional

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
-- repo: git://github.com/antonbabenko/pre-commit-terraform
+- repo: https://github.com/antonbabenko/pre-commit-terraform
   rev: v1.24.0
   hooks:
     - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Create and manage a [Route 53 Resolver Resolver Rule](https://docs.aws.amazon.co
 ## Usage
 
 ```
+# Create a rule and assign it to a given VPC
 module "route53-rule-ad-corp" {
   source            = "git::https://github.com/rhythmictech/terraform-aws-route53-resolver-rule?ref=v0.0.2"
   associated_vpcs   = ["vpc-1234567"]
@@ -13,6 +14,15 @@ module "route53-rule-ad-corp" {
   forward_ips       = ["192.168.100.10", "192.168.100.11"]
   resolver_endpoint = module.route53-outbound.endpoint_id
 }
+
+# Create a rule without VPC assignment(and share it via RAM)
+module "route53-rule-ad-corp" {
+  source            = "git::https://github.com/rhythmictech/terraform-aws-route53-resolver-rule?ref=v0.0.2"
+  forward_domain    = "ad.mycompany.com."
+  forward_ips       = ["192.168.100.10", "192.168.100.11"]
+  resolver_endpoint = module.route53-outbound.endpoint_id
+}
+
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ module "route53-rule-ad-corp" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| associated\_vpcs | List of VPC IDs to associate rule to | `list(string)` | n/a | yes |
+| associated\_vpcs | List of VPC IDs to associate rule to | `list(string)` | null | no |
 | dns\_port | DNS port to forward DNS requests to | `number` | `53` | no |
 | forward\_domain | Domain name to forward requests for | `string` | n/a | yes |
 | forward\_ips | List of IPs to forward DNS requests to | `list(string)` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_route53_resolver_rule" "fwd" {
 }
 
 resource "aws_route53_resolver_rule_association" "fwdrule" {
-  count            = length(var.associated_vpcs)
+  count            = length(var.associated_vpcs) > 0 ? length(var.associated_vpcs) : 0
   resolver_rule_id = aws_route53_resolver_rule.fwd.id
   vpc_id           = var.associated_vpcs[count.index]
 }

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ resource "aws_route53_resolver_rule" "fwd" {
 }
 
 resource "aws_route53_resolver_rule_association" "fwdrule" {
-  count            = length(var.associated_vpcs) > 0 ? length(var.associated_vpcs) : 0
+  count            = var.associated_vpcs != null ? length(var.associated_vpcs) : 0
   resolver_rule_id = aws_route53_resolver_rule.fwd.id
   vpc_id           = var.associated_vpcs[count.index]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "associated_vpcs" {
   description = "List of VPC IDs to associate rule to"
   type        = list(string)
+  default     = null
 }
 
 variable "forward_domain" {


### PR DESCRIPTION
Hi,

I am working on screnario 3 of that post:

[Simplify DNS management in a multi-account environment with Route 53 Resolver](https://aws.amazon.com/blogs/security/simplify-dns-management-in-a-multiaccount-environment-with-route-53-resolver/)

It is needed to create a resolver rule which is shared via RAM(Resource Access Manager) but not assign to any local VPC. 

It tested my branch against our infrastructure with and without VPC assignments without having issues.

